### PR TITLE
[#37,#38,#39,#40,#42] Quality fixes from tester-agent audit

### DIFF
--- a/apps/backend/src/automation/automation.controller.spec.ts
+++ b/apps/backend/src/automation/automation.controller.spec.ts
@@ -50,6 +50,7 @@ describe('AutomationController', () => {
       'run-1',
       dto.results[0],
       'proj-1',
+      'key-1',
     );
     expect(result.submitted).toBe(1);
   });

--- a/apps/backend/src/automation/automation.service.spec.ts
+++ b/apps/backend/src/automation/automation.service.spec.ts
@@ -12,6 +12,7 @@ describe('AutomationService', () => {
     testRun: { create: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
     testRunCase: { findFirst: jest.fn() },
     testResult: { create: jest.fn() },
+    apiKey: { findUnique: jest.fn() },
   };
 
   const mockRunEventsService = { emitUpdate: jest.fn() };
@@ -78,9 +79,10 @@ describe('AutomationService', () => {
         id: 'result-1', status: 'PASSED', testRunCaseId: 'trc-1',
       });
 
+      mockPrisma.apiKey.findUnique.mockResolvedValue({ createdById: 'user-1' });
       const result = await service.submitResult('run-1', {
         automationId: 'test.spec.ts > test', status: 'PASSED', duration: 1500,
-      }, 'proj-1');
+      }, 'proj-1', 'key-1');
 
       expect(result).not.toBeNull();
       expect(mockPrisma.testResult.create).toHaveBeenCalled();
@@ -90,7 +92,7 @@ describe('AutomationService', () => {
       mockPrisma.testRunCase.findFirst.mockResolvedValue(null);
       const result = await service.submitResult('run-1', {
         automationId: 'unknown', status: 'PASSED',
-      }, 'proj-1');
+      }, 'proj-1', 'key-1');
       expect(result).toBeNull();
     });
 
@@ -101,9 +103,10 @@ describe('AutomationService', () => {
       mockPrisma.testRun.update.mockResolvedValue({});
       mockPrisma.testResult.create.mockResolvedValue({ id: 'r-1', status: 'PASSED' });
 
+      mockPrisma.apiKey.findUnique.mockResolvedValue({ createdById: 'user-1' });
       await service.submitResult('run-1', {
         automationId: 'test', status: 'PASSED',
-      }, 'proj-1');
+      }, 'proj-1', 'key-1');
 
       expect(mockPrisma.testRun.update).toHaveBeenCalledWith({
         where: { id: 'run-1' },

--- a/apps/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/apps/frontend/app/(dashboard)/dashboard/page.tsx
@@ -259,13 +259,13 @@ export default function DashboardPage() {
             href="/projects"
             icon={Play}
             title="Test Runs"
-            description="Execute test plans and record results"
+            description="Select a project to view and execute test runs"
           />
           <QuickLink
             href="/projects"
             icon={BarChart3}
             title="Reports"
-            description="View coverage and progress metrics"
+            description="Select a project to view test reports and analytics"
           />
         </div>
       </div>

--- a/apps/frontend/app/(dashboard)/layout.tsx
+++ b/apps/frontend/app/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import {
   LayoutDashboard,
   FolderKanban,
+  Key,
   Users,
   Settings,
   LogOut,
@@ -30,6 +31,7 @@ const adminNav: NavItem[] = [
 ];
 
 const bottomNav: NavItem[] = [
+  { label: 'API Keys', href: '/settings/api-keys', icon: Key },
   { label: 'Settings', href: '/settings', icon: Settings },
 ];
 

--- a/apps/frontend/app/(dashboard)/projects/[id]/runs/[runId]/execute/page.tsx
+++ b/apps/frontend/app/(dashboard)/projects/[id]/runs/[runId]/execute/page.tsx
@@ -17,7 +17,8 @@ import type {
   TestRunCaseWithResultDto,
   SubmitTestResultInput,
 } from '@app/shared';
-import { TestResultStatus, CasePriority, CaseType } from '@app/shared';
+import { TestResultStatus, TestRunStatus, CasePriority, CaseType } from '@app/shared';
+import { toast } from 'sonner';
 import {
   useTestExecution,
   useSubmitResult,
@@ -79,6 +80,7 @@ export default function ExecutePage({
   const cases = execution?.testRunCases ?? [];
   const activeCase: TestRunCaseWithResultDto | undefined = cases[activeCaseIndex];
   const steps: TestCaseStepDto[] = activeCase?.testCase.steps ?? [];
+  const isRunClosed = execution?.status === TestRunStatus.COMPLETED;
 
   const caseStatus = useCallback(
     (trc: TestRunCaseWithResultDto): TestResultStatus =>
@@ -165,6 +167,9 @@ export default function ExecutePage({
           setActiveCaseIndex(activeCaseIndex + 1);
         }
       },
+      onError: (error: Error) => {
+        toast.error(error.message || 'Failed to submit result');
+      },
     });
   }
 
@@ -201,11 +206,18 @@ export default function ExecutePage({
 
     if (untestedIds.length === 0) return;
 
-    bulkSubmit.mutate({
-      testRunCaseIds: untestedIds,
-      status: 'PASSED',
-      comment: 'Bulk submitted as passed',
-    });
+    bulkSubmit.mutate(
+      {
+        testRunCaseIds: untestedIds,
+        status: 'PASSED',
+        comment: 'Bulk submitted as passed',
+      },
+      {
+        onError: (error: Error) => {
+          toast.error(error.message || 'Failed to submit results');
+        },
+      },
+    );
   }
 
   function selectCase(index: number) {
@@ -272,6 +284,13 @@ export default function ExecutePage({
               ]}
             />
 
+            {/* Completed run banner */}
+            {isRunClosed && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                This run is completed. Results cannot be modified.
+              </div>
+            )}
+
             {/* Case header */}
             <div className="space-y-3">
               <div className="flex items-start justify-between gap-4">
@@ -317,6 +336,7 @@ export default function ExecutePage({
                 size="sm"
                 className="gap-1.5 bg-emerald-600 hover:bg-emerald-700 text-white"
                 onClick={handlePassAllSteps}
+                disabled={isRunClosed}
               >
                 <Zap className="size-3.5" />
                 Pass All Steps
@@ -326,6 +346,7 @@ export default function ExecutePage({
                 size="sm"
                 className="gap-1.5"
                 onClick={handleSkipCase}
+                disabled={isRunClosed}
               >
                 <SkipForward className="size-3.5" />
                 Skip
@@ -335,6 +356,7 @@ export default function ExecutePage({
                 className="gap-1.5"
                 onClick={() => handleSubmitCase()}
                 disabled={
+                  isRunClosed ||
                   submitResult.isPending ||
                   (steps.length > 0 && !computedOverallStatus)
                 }
@@ -348,7 +370,7 @@ export default function ExecutePage({
                   size="sm"
                   className="gap-1.5 text-muted-foreground"
                   onClick={handleBulkSubmitAll}
-                  disabled={bulkSubmit.isPending}
+                  disabled={isRunClosed || bulkSubmit.isPending}
                 >
                   <CheckCircle2 className="size-3.5" />
                   {bulkSubmit.isPending ? 'Submitting...' : 'Submit All Remaining'}

--- a/apps/frontend/app/(dashboard)/projects/[id]/runs/[runId]/page.tsx
+++ b/apps/frontend/app/(dashboard)/projects/[id]/runs/[runId]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation';
+
+export default async function TestRunPage({
+  params,
+}: {
+  params: Promise<{ id: string; runId: string }>;
+}) {
+  const { id, runId } = await params;
+  redirect(`/projects/${id}/runs/${runId}/execute`);
+}

--- a/apps/frontend/app/(dashboard)/settings/api-keys/page.tsx
+++ b/apps/frontend/app/(dashboard)/settings/api-keys/page.tsx
@@ -128,7 +128,9 @@ export default function ApiKeysPage() {
               disabled={loadingProjects}
             >
               <SelectTrigger className="w-full max-w-xs">
-                <SelectValue placeholder="Select a project..." />
+                <SelectValue placeholder="Select a project...">
+                  {projects?.find((p) => p.id === selectedProjectId)?.name}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {projects?.map((p) => (

--- a/apps/frontend/app/(dashboard)/settings/page.tsx
+++ b/apps/frontend/app/(dashboard)/settings/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useForm } from 'react-hook-form';
-import { Check, Loader2 } from 'lucide-react';
+import { Check, Key, Loader2 } from 'lucide-react';
 import { UpdateProfileSchema } from '@app/shared';
 import { useAuth } from '@/lib/auth/useAuth';
 import { useUpdateProfile } from '@/lib/users/useProfile';
@@ -186,6 +187,24 @@ export default function SettingsPage() {
                 )}
               </div>
             </form>
+          </CardContent>
+        </Card>
+
+        {/* API Keys */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Key className="size-4" />
+              API Keys
+            </CardTitle>
+            <CardDescription>
+              Manage API keys for Playwright automation integration
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link href="/settings/api-keys">
+              <Button variant="outline">Manage API Keys</Button>
+            </Link>
           </CardContent>
         </Card>
       </div>

--- a/apps/frontend/components/test-cases/CaseEditor.tsx
+++ b/apps/frontend/components/test-cases/CaseEditor.tsx
@@ -396,7 +396,15 @@ export function CaseEditor({ projectId, caseId }: CaseEditorProps) {
           {effectiveTemplate === TemplateType.STEPS && (
             <div className="space-y-2">
               <Label>Test Steps ({steps.length})</Label>
-              <StepEditor steps={steps} onChange={setSteps} />
+              {steps.length === 0 && testCase.automationStatus === AutomationStatus.AUTOMATED ? (
+                <div className="rounded-lg border border-dashed py-6 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    This is an automated test — manual steps are not required.
+                  </p>
+                </div>
+              ) : (
+                <StepEditor steps={steps} onChange={setSteps} />
+              )}
             </div>
           )}
 
@@ -411,23 +419,28 @@ export function CaseEditor({ projectId, caseId }: CaseEditorProps) {
               </p>
             ) : (
               <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Badge variant={testCase.automationStatus === AutomationStatus.AUTOMATED ? 'default' : 'destructive'}>
-                    {testCase.automationStatus === AutomationStatus.AUTOMATED ? 'Automated' : 'Needs Update'}
-                  </Badge>
-                </div>
+                <Badge variant={testCase.automationStatus === AutomationStatus.AUTOMATED ? 'default' : 'destructive'}>
+                  {testCase.automationStatus === AutomationStatus.AUTOMATED ? 'Automated' : 'Needs Update'}
+                </Badge>
                 {testCase.automationId && (
                   <div>
-                    <span className="text-xs text-muted-foreground">Automation ID</span>
-                    <p className="font-mono text-xs break-all">{testCase.automationId}</p>
+                    <span className="text-xs font-medium text-muted-foreground">Automation ID</span>
+                    <p className="rounded bg-muted px-2 py-1 font-mono text-xs break-all">
+                      {testCase.automationId}
+                    </p>
                   </div>
                 )}
                 {testCase.automationFilePath && (
                   <div>
-                    <span className="text-xs text-muted-foreground">File</span>
-                    <p className="font-mono text-xs break-all">{testCase.automationFilePath}</p>
+                    <span className="text-xs font-medium text-muted-foreground">Spec File</span>
+                    <p className="rounded bg-muted px-2 py-1 font-mono text-xs break-all">
+                      {testCase.automationFilePath}
+                    </p>
                   </div>
                 )}
+                <p className="text-xs text-muted-foreground">
+                  This test case is linked to an automated Playwright test.
+                </p>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Quality improvements found during comprehensive tester-agent UI audit of the Playwright automation feature.

- **#37**: Disable action buttons on completed runs, show "run completed" banner, add error toasts on 409 submission failure
- **#38**: Fix API keys page — project dropdown shows names instead of raw CUIDs, add nav link in sidebar + settings page
- **#39**: Show automationId and filePath in case editor automation section, show "automated test — no manual steps required" message
- **#40**: Add `/projects/:id/runs/:runId` redirect page (was 404), improve dashboard quick-action card descriptions
- **#42**: UI polish across settings, dashboard, and case editor

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] Backend tests — 453/454 pass (1 pre-existing failure unrelated)
- [ ] Manual: verify completed run shows disabled buttons + info banner
- [ ] Manual: verify API keys page dropdown shows project names
- [ ] Manual: verify `/projects/:id/runs/:runId` redirects to execute page

Closes #37
Closes #38
Closes #39
Closes #40
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)