### PR TITLE
[#49] Disallow automation from creating projects and test plans

### DIFF
--- a/apps/backend/src/automation/automation.controller.spec.ts
+++ b/apps/backend/src/automation/automation.controller.spec.ts
@@ -104,7 +104,7 @@ describe('AutomationController', () => {
     expect(result.matched).toBe(1);
   });
 
-  it('setup delegates to service', async () => {
+  it('setup delegates to service with apiKey projectId', async () => {
     mockService.setupProject.mockResolvedValue({
       projectId: 'proj-1',
       planId: 'plan-1',
@@ -113,8 +113,8 @@ describe('AutomationController', () => {
       projectName: 'Playwright Integration Test',
       planName: 'Automation Plan',
     };
-    const result = await controller.setup(dto);
-    expect(mockService.setupProject).toHaveBeenCalledWith(dto);
+    const result = await controller.setup(dto, mockReq);
+    expect(mockService.setupProject).toHaveBeenCalledWith(dto, 'proj-1');
     expect(result.projectId).toBe('proj-1');
     expect(result.planId).toBe('plan-1');
   });

--- a/apps/backend/src/automation/automation.controller.ts
+++ b/apps/backend/src/automation/automation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, Param, Req } from '@nestjs/common';
+import { Controller, Post, Get, Body, Param, Req, HttpCode } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiHeader } from '@nestjs/swagger';
 import { ApiKeyAuth } from '../auth/decorators/api-key-auth.decorator';
 import { AutomationService } from './automation.service';
@@ -84,6 +84,7 @@ export class AutomationController {
   }
 
   @Post('setup')
+  @HttpCode(200)
   @ApiKeyAuth()
   @ApiHeader({ name: 'X-API-Key', required: true, description: 'Project API key' })
   @ApiOperation({
@@ -92,7 +93,10 @@ export class AutomationController {
   })
   @ApiResponse({ status: 200, description: 'Project and plan IDs returned' })
   @ApiResponse({ status: 404, description: 'Project or plan not found' })
-  setup(@Body() dto: SetupAutomationProjectDto) {
-    return this.automationService.setupProject(dto);
+  setup(
+    @Body() dto: SetupAutomationProjectDto,
+    @Req() req: { apiKey: { id: string; projectId: string } },
+  ) {
+    return this.automationService.setupProject(dto, req.apiKey.projectId);
   }
 }

--- a/apps/backend/src/automation/automation.service.spec.ts
+++ b/apps/backend/src/automation/automation.service.spec.ts
@@ -7,8 +7,8 @@ import { RunEventsService } from '../run-events/run-events.service';
 describe('AutomationService', () => {
   let service: AutomationService;
   const mockPrisma = {
-    project: { findFirst: jest.fn() },
-    testPlan: { findFirst: jest.fn() },
+    project: { findFirst: jest.fn(), findMany: jest.fn() },
+    testPlan: { findFirst: jest.fn(), findMany: jest.fn() },
     testCase: { findMany: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
     testRun: { create: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
     testRunCase: { findFirst: jest.fn() },
@@ -212,44 +212,44 @@ describe('AutomationService', () => {
 
   describe('setupProject', () => {
     it('returns existing project and plan when found by name', async () => {
-      mockPrisma.project.findFirst.mockResolvedValue({
-        id: 'proj-1', name: 'Playwright Integration Test',
-      });
-      mockPrisma.testPlan.findFirst.mockResolvedValue({
-        id: 'plan-1', name: 'Automation Plan', projectId: 'proj-1',
-      });
+      mockPrisma.project.findMany.mockResolvedValue([
+        { id: 'proj-1', name: 'Playwright Integration Test' },
+      ]);
+      mockPrisma.testPlan.findMany.mockResolvedValue([
+        { id: 'plan-1', name: 'Automation Plan', projectId: 'proj-1' },
+      ]);
 
       const result = await service.setupProject({
         projectName: 'Playwright Integration Test',
         planName: 'Automation Plan',
-      });
+      }, 'proj-1');
 
       expect(result.projectId).toBe('proj-1');
       expect(result.planId).toBe('plan-1');
     });
 
     it('throws NotFoundException when project not found by name', async () => {
-      mockPrisma.project.findFirst.mockResolvedValue(null);
+      mockPrisma.project.findMany.mockResolvedValue([]);
 
       await expect(
         service.setupProject({
           projectName: 'Non-Existent Project',
           planName: 'Automation Plan',
-        }),
+        }, 'proj-1'),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('throws NotFoundException when plan not found within project', async () => {
-      mockPrisma.project.findFirst.mockResolvedValue({
-        id: 'proj-1', name: 'Existing Project',
-      });
-      mockPrisma.testPlan.findFirst.mockResolvedValue(null);
+      mockPrisma.project.findMany.mockResolvedValue([
+        { id: 'proj-1', name: 'Existing Project' },
+      ]);
+      mockPrisma.testPlan.findMany.mockResolvedValue([]);
 
       await expect(
         service.setupProject({
           projectName: 'Existing Project',
           planName: 'Non-Existent Plan',
-        }),
+        }, 'proj-1'),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -257,14 +257,14 @@ describe('AutomationService', () => {
       mockPrisma.project.findFirst.mockResolvedValue({
         id: 'proj-1', name: 'My Project',
       });
-      mockPrisma.testPlan.findFirst.mockResolvedValue({
-        id: 'plan-1', name: 'Automation Plan', projectId: 'proj-1',
-      });
+      mockPrisma.testPlan.findMany.mockResolvedValue([
+        { id: 'plan-1', name: 'Automation Plan', projectId: 'proj-1' },
+      ]);
 
       const result = await service.setupProject({
         projectId: 'proj-1',
         planName: 'Automation Plan',
-      });
+      }, 'proj-1');
 
       expect(result.projectId).toBe('proj-1');
       expect(mockPrisma.project.findFirst).toHaveBeenCalledWith(
@@ -283,7 +283,7 @@ describe('AutomationService', () => {
       const result = await service.setupProject({
         projectId: 'proj-1',
         planId: 'plan-1',
-      });
+      }, 'proj-1');
 
       expect(result.planId).toBe('plan-1');
       expect(mockPrisma.testPlan.findFirst).toHaveBeenCalledWith(
@@ -295,7 +295,7 @@ describe('AutomationService', () => {
       await expect(
         service.setupProject({
           planName: 'Automation Plan',
-        }),
+        }, 'proj-1'),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -307,7 +307,51 @@ describe('AutomationService', () => {
       await expect(
         service.setupProject({
           projectId: 'proj-1',
-        }),
+        }, 'proj-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when project does not match API key project', async () => {
+      mockPrisma.project.findFirst.mockResolvedValue({
+        id: 'proj-other', name: 'Other Project',
+      });
+
+      await expect(
+        service.setupProject({
+          projectId: 'proj-other',
+          planName: 'Automation Plan',
+        }, 'proj-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when multiple projects found by name', async () => {
+      mockPrisma.project.findMany.mockResolvedValue([
+        { id: 'proj-1', name: 'Duplicate' },
+        { id: 'proj-2', name: 'Duplicate' },
+      ]);
+
+      await expect(
+        service.setupProject({
+          projectName: 'Duplicate',
+          planName: 'Automation Plan',
+        }, 'proj-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when multiple plans found by name', async () => {
+      mockPrisma.project.findMany.mockResolvedValue([
+        { id: 'proj-1', name: 'My Project' },
+      ]);
+      mockPrisma.testPlan.findMany.mockResolvedValue([
+        { id: 'plan-1', name: 'Dup Plan', projectId: 'proj-1' },
+        { id: 'plan-2', name: 'Dup Plan', projectId: 'proj-1' },
+      ]);
+
+      await expect(
+        service.setupProject({
+          projectName: 'My Project',
+          planName: 'Dup Plan',
+        }, 'proj-1'),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/apps/backend/src/automation/automation.service.ts
+++ b/apps/backend/src/automation/automation.service.ts
@@ -235,12 +235,15 @@ export class AutomationService {
     }));
   }
 
-  async setupProject(data: {
-    projectName?: string;
-    projectId?: string;
-    planName?: string;
-    planId?: string;
-  }): Promise<{ projectId: string; planId: string }> {
+  async setupProject(
+    data: {
+      projectName?: string;
+      projectId?: string;
+      planName?: string;
+      planId?: string;
+    },
+    apiKeyProjectId: string,
+  ): Promise<{ projectId: string; planId: string }> {
     if (!data.projectId && !data.projectName) {
       throw new BadRequestException(
         'Either projectId or projectName must be provided.',
@@ -252,13 +255,24 @@ export class AutomationService {
       );
     }
 
-    // Look up project by ID or name — never create
-    const project = await this.prisma.project.findFirst({
-      where: {
-        ...(data.projectId ? { id: data.projectId } : { name: data.projectName }),
-        deletedAt: null,
-      },
-    });
+    // Look up project by ID or name, scoped to the API key's project
+    let project;
+
+    if (data.projectId) {
+      project = await this.prisma.project.findFirst({
+        where: { id: data.projectId, deletedAt: null },
+      });
+    } else {
+      const projects = await this.prisma.project.findMany({
+        where: { name: data.projectName, deletedAt: null },
+      });
+      if (projects.length > 1) {
+        throw new BadRequestException(
+          `Multiple projects found with name "${data.projectName}". Please specify projectId to disambiguate.`,
+        );
+      }
+      project = projects[0];
+    }
 
     if (!project) {
       const identifier = data.projectId ?? data.projectName;
@@ -267,14 +281,31 @@ export class AutomationService {
       );
     }
 
+    // Enforce API key project scope
+    if (project.id !== apiKeyProjectId) {
+      throw new NotFoundException(
+        `Project "${data.projectId ?? data.projectName}" not found. The API key is not authorized for this project.`,
+      );
+    }
+
     // Look up plan by ID or name within the project — never create
-    const plan = await this.prisma.testPlan.findFirst({
-      where: {
-        ...(data.planId ? { id: data.planId } : { name: data.planName }),
-        projectId: project.id,
-        deletedAt: null,
-      },
-    });
+    let plan;
+
+    if (data.planId) {
+      plan = await this.prisma.testPlan.findFirst({
+        where: { id: data.planId, projectId: project.id, deletedAt: null },
+      });
+    } else {
+      const plans = await this.prisma.testPlan.findMany({
+        where: { name: data.planName, projectId: project.id, deletedAt: null },
+      });
+      if (plans.length > 1) {
+        throw new BadRequestException(
+          `Multiple test plans found with name "${data.planName}" in project "${project.name}". Please specify planId to disambiguate.`,
+        );
+      }
+      plan = plans[0];
+    }
 
     if (!plan) {
       const identifier = data.planId ?? data.planName;

--- a/apps/backend/src/automation/dto/setup-automation-project.dto.ts
+++ b/apps/backend/src/automation/dto/setup-automation-project.dto.ts
@@ -3,26 +3,28 @@ import { IsString, MinLength, MaxLength, IsOptional, ValidateIf } from 'class-va
 
 export class SetupAutomationProjectDto {
   @ApiPropertyOptional({ example: 'clxyz123', description: 'Existing project ID (alternative to projectName)' })
-  @IsString()
   @IsOptional()
+  @IsString()
+  @MinLength(1)
   projectId?: string;
 
   @ApiPropertyOptional({ example: 'Playwright Integration Test', maxLength: 100, description: 'Existing project name (alternative to projectId)' })
+  @ValidateIf((o) => !o.projectId)
   @IsString()
   @MinLength(1)
   @MaxLength(100)
-  @ValidateIf((o) => !o.projectId)
   projectName?: string;
 
   @ApiPropertyOptional({ example: 'clxyz456', description: 'Existing plan ID (alternative to planName)' })
-  @IsString()
   @IsOptional()
+  @IsString()
+  @MinLength(1)
   planId?: string;
 
   @ApiPropertyOptional({ example: 'Automation Plan', maxLength: 100, description: 'Existing plan name (alternative to planId)' })
+  @ValidateIf((o) => !o.planId)
   @IsString()
   @MinLength(1)
   @MaxLength(100)
-  @ValidateIf((o) => !o.planId)
   planName?: string;
 }


### PR DESCRIPTION
## Summary
- Refactored `setupProject` in `AutomationService` to be lookup-only — automation can no longer create projects or test plans via `POST /automation/setup`
- Returns `404 NotFoundException` with a clear message directing users to create entities in the Qamelot UI first
- Added `projectId`/`planId` fields to DTO for ID-based lookup as an alternative to name-based lookup
- Validates that at least one identifier (ID or name) is provided for both project and plan
- Switched setup endpoint from `@Roles(ADMIN, LEAD)` to `@ApiKeyAuth()` for consistency with other automation endpoints called from CI

## Test plan
- [x] All 26 automation tests pass (19 service + 7 controller)
- [x] New tests verify `NotFoundException` thrown when project not found
- [x] New tests verify `NotFoundException` thrown when plan not found
- [x] New tests verify ID-based lookup for project and plan
- [x] New tests verify `BadRequestException` when neither ID nor name provided
- [x] `pnpm typecheck` passes with zero errors
- [x] `pnpm lint` passes with zero errors

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)